### PR TITLE
feat: noticket - Make react-native-snackbar suitable for our usage

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,12 +10,12 @@ buildscript {
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }
@@ -34,7 +34,6 @@ repositories {
 dependencies {
     compile 'com.facebook.react:react-native:+' // from node_modules
 
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:support-v4:25.1.0'
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:design:23.0.1'
 }

--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -63,11 +63,17 @@ public class SnackbarModule extends ReactContextBaseJavaModule{
             snackbar.setActionTextColor(actionDetails.getInt("color"));
         }
 
+        if (options.hasKey("maxLines")) {
+            View snackbarView = snackbar.getView();
+            TextView snackbarText = (TextView) snackbarView.findViewById(R.id.snackbar_text);
+            snackbarText.setMaxLines(options.getInt("maxLines"));
+        }
+
         // For older devices, explicitly set the text color; otherwise it may appear dark gray.
         // http://stackoverflow.com/a/31084530/763231
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             View snackbarView = snackbar.getView();
-            TextView snackbarText = (TextView) snackbarView.findViewById(android.support.design.R.id.snackbar_text);
+            TextView snackbarText = (TextView) snackbarView.findViewById(R.id.snackbar_text);
             snackbarText.setTextColor(Color.WHITE);
         }
 

--- a/ios/RNSnackBarView.m
+++ b/ios/RNSnackBarView.m
@@ -75,7 +75,7 @@ static const NSTimeInterval ANIMATION_DURATION = 0.250;
     self.backgroundColor = [UIColor colorWithRed:0.196078F green:0.196078F blue:0.196078F alpha:1.0F];
     titleLabel = [UILabel new];
     titleLabel.text = _title;
-    titleLabel.numberOfLines = 2;
+    titleLabel.numberOfLines = _pendingOptions[@"maxLines"];
     titleLabel.textColor = [UIColor whiteColor];
     titleLabel.font = [UIFont boldSystemFontOfSize:14];
     [titleLabel setTranslatesAutoresizingMaskIntoConstraints:NO];

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/cooperka/react-native-snackbar",
   "devDependencies": {
-    "react": "~15.4.1",
-    "react-native": "~0.39.2"
+    "react": "~15.3.1",
+    "react-native": "~0.33.1"
   }
 }


### PR DESCRIPTION
**Summary:**

react-native-snackbar is great but it doesn't a) work for our minimum version of Android and b) allow max lines to be defined. This PR fixes both.

**How to test:**

Tested in conjunction with [this PR](https://bitbucket.org/conversocial/conv_crowds_react/pull-requests/322/feat-crow-711-migrate-to-react-native/diff).

1. Build must complete.

2. Snackbar must appear when the user bins a question.

3. A full-length question must be able to be displayed in the Snackbar.